### PR TITLE
fix findContours outputs

### DIFF
--- a/Appendix A/auto_coloring.ipynb
+++ b/Appendix A/auto_coloring.ipynb
@@ -36,7 +36,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "_, contours, _ = cv2.findContours(gray_image, cv2.RETR_TREE,\n",
+    "contours, _ = cv2.findContours(gray_image, cv2.RETR_TREE,\n",
     "                                  cv2.CHAIN_APPROX_SIMPLE)\n",
     "for i,cnt in enumerate(contours):\n",
     "    gray_image = cv2.drawContours(gray_image, [cnt], 0, i+1, cv2.FILLED)\n",


### PR DESCRIPTION
付録Aのauto_coloring.ipynbを実行すると
p.391の部分で下記エラーが発生しております。

----------------------------------------------------------------
ValueError                     Traceback (most recent call last)
<ipython-input-10-aa668d450580> in <module>
      1 _, contours, _ = cv2.findContours(gray_image, cv2.RETR_TREE,
----> 2                                   cv2.CHAIN_APPROX_SIMPLE)
      3 for i,cnt in enumerate(contours):
      4     gray_image = cv2.drawContours(gray_image, [cnt], 0, i+1, cv2.FILLED)
      5 

ValueError: not enough values to unpack (expected 3, got 2)

![findContours](https://user-images.githubusercontent.com/48097078/56094173-16e71500-5f0c-11e9-9567-bc0ad8ece86c.png)

findContoursの戻り値を修正することでエラーが発生しなくなりましたので
お手すきの際にご確認お願いします。